### PR TITLE
Close button added to all form pages. XAML code refactored.

### DIFF
--- a/GeCO/GeCO/App.xaml
+++ b/GeCO/GeCO/App.xaml
@@ -198,37 +198,41 @@
                 <Setter Property="TextColor"                Value="{StaticResource NormalTextColor}" />
                 <Setter Property="FontSize"                 Value="Medium" />
                 <Setter Property="Margin"                   Value="0,-3,0,10" />
-            </Style>                                        
-                                                            
-                                                            
-                                                            
-                                                            
-            <Style x:Key="FormLeftButton"                   TargetType="Button">
-                <Setter Property="TextColor"                Value="{StaticResource SecondaryColor}" />
+            </Style>
+
+
+            <Style x:Key="FormBtn"                          TargetType="Button" >
                 <Setter Property="BackgroundColor"          Value="Transparent" />
                 <Setter Property="FontAttributes"           Value="Bold" />
                 <Setter Property="BorderWidth"              Value="1" />
-                <Setter Property="BorderColor"              Value="{StaticResource SecondaryColor}" />
-                <Setter Property="Margin"                   Value="15,15,5,10" />
                 <Setter Property="HorizontalOptions"        Value="FillAndExpand" />
-            </Style>                                        
+            </Style>                                  
                                                             
-            <Style x:Key="FormRightButton"                  TargetType="Button">
+            <Style x:Key="FormLeftButton"                   TargetType="Button" BasedOn="{StaticResource FormBtn}">
+                <Setter Property="TextColor"                Value="{StaticResource SecondaryColor}" />
+                <Setter Property="BorderColor"              Value="{StaticResource SecondaryColor}" />
+                <Setter Property="Margin"                   Value="15,15,5,0" />
+                
+            </Style>
+
+            <Style x:Key="FormRightButton"                  TargetType="Button" BasedOn="{StaticResource FormBtn}">
                 <Setter Property="TextColor"                Value="{StaticResource PrimaryTextColor}" />
                 <Setter Property="BackgroundColor"          Value="{StaticResource SecondaryColor}" />
-                <Setter Property="FontAttributes"           Value="Bold" />
-                <Setter Property="BorderWidth"              Value="1" />
-                <Setter Property="BorderColor"              Value="{StaticResource SecondaryColor}" />
-                <Setter Property="Margin"                   Value="5,15,15,10" />
-                <Setter Property="HorizontalOptions"        Value="FillAndExpand" />
+                <Setter Property="Margin"                   Value="5,15,15,0" />
                 <Setter Property="ContentLayout"            Value="Right, 0" />
-            </Style>                                        
-                                                            
-            <Style x:Key="FormCancelButton"                 TargetType="Button" BasedOn="{StaticResource FormLeftButton}">
+            </Style>
+
+            <Style x:Key="FormCancelButton"                 TargetType="Button" BasedOn="{StaticResource FormBtn}">
                 <Setter Property="TextColor"                Value="{StaticResource WarningColor}" />
                 <Setter Property="BorderColor"              Value="{StaticResource WarningColor}" />
-            </Style>                                        
-                                                            
+                <Setter Property="Margin"                   Value="15,5,15,-20" />
+            </Style>
+            
+            <Style x:Key="CancelBtnPrincPage"               TargetType="Button" BasedOn="{StaticResource FormLeftButton}">
+                <Setter Property="TextColor"                Value="{StaticResource WarningColor}" />
+                <Setter Property="BorderColor"              Value="{StaticResource WarningColor}" />
+            </Style>
+
             <Style x:Key="FormLabel"                        TargetType="Label">
                 <Setter Property="TextColor"                Value="{StaticResource NormalTextColor}" />               
                 <Setter Property="FontSize"                 Value="15" />

--- a/GeCO/GeCO/ViewModels/AutoApreensaoVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoApreensaoVM.cs
@@ -19,6 +19,8 @@ namespace GeCO.ViewModels
         }
 
 
+
+        #region Gets
         public async Task<Geral> GetGeral(int id) {
             return await App.Database.GetGeral(id);
         }
@@ -27,15 +29,17 @@ namespace GeCO.ViewModels
             return await App.Database.GetApreensao(id);
         }
 
-        public async Task<Lei> GetLei(int id) {
+        public async Task<Lei> GetLei(int id)
+        {
             if (id != 0)
                 return await App.Database.GetLei(id);
-            
+
             return null;
         }
+        #endregion
 
 
-
+        #region Saves
         /// <summary>
         /// Insere (ou atualiza) a tabela Apreensao com o input das entries. Retornar o id da apreensao
         /// </summary>
@@ -43,8 +47,10 @@ namespace GeCO.ViewModels
             apreensao = await App.Database.SaveApreensao(apreensao, autoId);
             return apreensao.ApreensaoId;
         }
+        #endregion
 
 
+        #region Deletes
         /// <summary>
         /// Apaga a atual apreensao (row) da tabela Apreensao.
         /// </summary>
@@ -56,8 +62,29 @@ namespace GeCO.ViewModels
             catch { Debug.WriteLine("Erro ao apagar apreensao. AutoApreensaoVM.cs, ApagarApreensao()."); }
         }
 
+        /// <summary>
+        /// Apaga o Auto (Geral) da base de dados
+        /// </summary>
+        public async Task ApagarAuto(int id) {
+            var geral = await App.Database.GetGeral(id);
+
+            var aut = await App.Database.GetAutuante(geral.AutuanteId);
+            await App.Database.ApagarAutuante(aut);
+
+            var apr = await App.Database.GetApreensao(geral.ApreensaoId);
+            await App.Database.ApagarApreensao(apr);
+
+            var pag = await App.Database.GetPagamento(geral.PagamentoId);
+            await App.Database.ApagarPagamento(pag);
+
+            await App.Database.ApagarGeral(geral);
+        }
+        #endregion
 
 
+
+
+        #region getters/setters
         public Apreensao Apreensao {
             get { return _apreensao; }
             set {
@@ -65,7 +92,10 @@ namespace GeCO.ViewModels
                 OnPropertyChanged();
             }
         }
+        #endregion
 
+
+        #region Properties
         private void InicializacaoPropriedades() {
             Apreensao = new Apreensao {
                 Objeto =        "Não Definido",
@@ -77,8 +107,10 @@ namespace GeCO.ViewModels
                 Motivo =        ""
             };
         }
+        #endregion
 
-#region REGION -> Lists
+
+        #region Lists (objetos, leis, tipos)
         List<String> objetos = new List<string> {
             "Não Definido",
             "Objeto 1",
@@ -107,6 +139,6 @@ namespace GeCO.ViewModels
             "Definitiva",
             "Temporária"
         };
-#endregion
+        #endregion
     }
 }

--- a/GeCO/GeCO/ViewModels/AutoArguidoVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoArguidoVM.cs
@@ -106,7 +106,25 @@ namespace GeCO.ViewModels {
         public async Task DesassociarPessoa(int pessoaId, int autoId) {
             await App.Database.UpdateArguido(pessoaId, autoId);
         }
-#endregion
+
+        /// <summary>
+        /// Apaga o Auto (Geral) da base de dados
+        /// </summary>
+        public async Task ApagarAuto(int id) {
+            var geral = await App.Database.GetGeral(id);
+
+            var aut = await App.Database.GetAutuante(geral.AutuanteId);
+            await App.Database.ApagarAutuante(aut);
+
+            var apr = await App.Database.GetApreensao(geral.ApreensaoId);
+            await App.Database.ApagarApreensao(apr);
+
+            var pag = await App.Database.GetPagamento(geral.PagamentoId);
+            await App.Database.ApagarPagamento(pag);
+
+            await App.Database.ApagarGeral(geral);
+        }
+        #endregion
 
 
         #region gettets/setters

--- a/GeCO/GeCO/ViewModels/AutoLegislacaoVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoLegislacaoVM.cs
@@ -52,6 +52,25 @@ namespace GeCO.ViewModels {
         public async Task ApagarLei(int leiId, int autoId) {
             await App.Database.UpdateLei(leiId, autoId);
         }
+
+
+        /// <summary>
+        /// Apaga o Auto (Geral) da base de dados
+        /// </summary>
+        public async Task ApagarAuto(int id) {
+            var geral = await App.Database.GetGeral(id);
+
+            var aut = await App.Database.GetAutuante(geral.AutuanteId);
+            await App.Database.ApagarAutuante(aut);
+
+            var apr = await App.Database.GetApreensao(geral.ApreensaoId);
+            await App.Database.ApagarApreensao(apr);
+
+            var pag = await App.Database.GetPagamento(geral.PagamentoId);
+            await App.Database.ApagarPagamento(pag);
+
+            await App.Database.ApagarGeral(geral);
+        } 
         #endregion
 
 

--- a/GeCO/GeCO/ViewModels/AutoPagamentoVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoPagamentoVM.cs
@@ -30,6 +30,28 @@ namespace GeCO.ViewModels {
         #endregion
 
 
+        #region Delete
+        /// <summary>
+        /// Apaga o Auto (Geral) da base de dados
+        /// </summary>
+        public async Task ApagarAuto(int id) {
+            var geral = await App.Database.GetGeral(id);
+
+            var aut = await App.Database.GetAutuante(geral.AutuanteId);
+            await App.Database.ApagarAutuante(aut);
+
+            var apr = await App.Database.GetApreensao(geral.ApreensaoId);
+            await App.Database.ApagarApreensao(apr);
+
+            var pag = await App.Database.GetPagamento(geral.PagamentoId);
+            await App.Database.ApagarPagamento(pag);
+
+            await App.Database.ApagarGeral(geral);
+        }
+        #endregion
+
+
+
         #region gettets/setters
 
         public Pagamento Pagamento {

--- a/GeCO/GeCO/ViewModels/AutoResumoVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoResumoVM.cs
@@ -10,6 +10,8 @@ namespace GeCO.ViewModels {
         }
 
 
+
+        #region Delete
         /// <summary>
         /// Apaga o Auto (Geral) da base de dados
         /// </summary>
@@ -27,5 +29,6 @@ namespace GeCO.ViewModels {
 
             await App.Database.ApagarGeral(geral);
         }
+        #endregion
     }
 }

--- a/GeCO/GeCO/ViewModels/AutoTestemunhaVM.cs
+++ b/GeCO/GeCO/ViewModels/AutoTestemunhaVM.cs
@@ -109,7 +109,25 @@ namespace GeCO.ViewModels {
         public async Task DesassociarPessoa(int pessoaId, int autoId) {
             await App.Database.UpdateTestemunha(pessoaId, autoId);
         }
-#endregion
+
+        /// <summary>
+        /// Apaga o Auto (Geral) da base de dados
+        /// </summary>
+        public async Task ApagarAuto(int id) {
+            var geral = await App.Database.GetGeral(id);
+
+            var aut = await App.Database.GetAutuante(geral.AutuanteId);
+            await App.Database.ApagarAutuante(aut);
+
+            var apr = await App.Database.GetApreensao(geral.ApreensaoId);
+            await App.Database.ApagarApreensao(apr);
+
+            var pag = await App.Database.GetPagamento(geral.PagamentoId);
+            await App.Database.ApagarPagamento(pag);
+
+            await App.Database.ApagarGeral(geral);
+        }
+        #endregion
 
 
         #region gettets/setters

--- a/GeCO/GeCO/Views/AutoApreensaoPage.xaml
+++ b/GeCO/GeCO/Views/AutoApreensaoPage.xaml
@@ -178,16 +178,23 @@
 
 
                 <!-- ~~~~~~ Botões ~~~~~~ -->
-                <StackLayout Orientation=   "Horizontal" >
-                    <Button Text=           "Anterior"
-                            Image=          "chevron_left_orange_24.png"
-                            Style=          "{StaticResource FormLeftButton}"
-                            Clicked=        "OnAnteriorClicked"/>
+                <StackLayout>
+                    <StackLayout Orientation=   "Horizontal" >
+                        <Button Text=           "Anterior"
+                                Image=          "chevron_left_orange_24.png"
+                                Style=          "{StaticResource FormLeftButton}"
+                                Clicked=        "OnAnteriorClicked"/>
                     
-                    <Button Text=           "Próximo"
-                            Image=          "chevron_right_24.png"
-                            Style=          "{StaticResource FormRightButton}"
-                            Clicked=        "OnProximoClicked"/>
+                        <Button Text=           "Próximo"
+                                Image=          "chevron_right_24.png"
+                                Style=          "{StaticResource FormRightButton}"
+                                Clicked=        "OnProximoClicked"/>
+                    
+                    </StackLayout>
+                    <Button Text=           "Cancelar"
+                            Image=          "close_red_24.png"
+                            Style=          "{StaticResource FormCancelButton}"
+                            Clicked=        "OnCancelClicked"/>
                 </StackLayout>
             </StackLayout>
         </ScrollView>

--- a/GeCO/GeCO/Views/AutoApreensaoPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoApreensaoPage.xaml.cs
@@ -13,13 +13,15 @@ namespace GeCO.Views {
     public partial class AutoApreensaoPage : ContentPage {
         private Apreensao _apreensao;
 
-        int currentAutoId, currentApreensaoId, currentLeiId;
+        private int currentAutoId, currentApreensaoId, currentLeiId;
+        private bool isNewAuto;
 
-        public AutoApreensaoPage(int id) {
+        public AutoApreensaoPage(int id, bool state) {
             InitializeComponent();
 
-            currentAutoId = id;
             BindingContext = new AutoApreensaoVM();
+            currentAutoId = id;
+            isNewAuto = state;
         }
 
 
@@ -93,13 +95,27 @@ namespace GeCO.Views {
 
             await loadAndSave();
 
-            var page = new AutoPagamentoPage(currentAutoId);
+            var page = new AutoPagamentoPage(currentAutoId, isNewAuto);
             await Navigation.PushAsync(page);
 
             IsEnabled = true;
         }
 
 
+        /// <summary>
+        /// Fecha todas as janelas do form e volta à página inicial. Se o utilizdor desejar pode também apagar a informação do auto.
+        /// </summary>
+        async void OnCancelClicked(object sender, System.EventArgs e) {
+            IsEnabled = false;
+
+            if (isNewAuto) {
+                bool isDeletable = await DisplayAlert("Atenção", "Está prestes a sair do formulário.\nPretende também apagar a informação já inserida?", "Sim", "Não");
+                if (isDeletable)
+                    await (BindingContext as AutoApreensaoVM).ApagarAuto(currentAutoId);
+            }
+            await Navigation.PopToRootAsync();
+            IsEnabled = true;
+        }
 
 
         /// <summary>
@@ -145,7 +161,7 @@ namespace GeCO.Views {
 
 
 
-        #region Properties
+        #region getters/setters
         public Apreensao Apreensao {
             get { return _apreensao; }
             set {

--- a/GeCO/GeCO/Views/AutoArguidoPage.xaml
+++ b/GeCO/GeCO/Views/AutoArguidoPage.xaml
@@ -253,16 +253,23 @@
 
 
                 <!-- ~~~~~~ Botões ~~~~~~ -->
-                <StackLayout Orientation=   "Horizontal" >
-                    <Button Text=           "Anterior"
-                            Image=          "chevron_left_orange_24.png"
-                            Style=          "{StaticResource FormLeftButton}"
-                            Clicked=        "OnAnteriorClicked"/>
-                    
-                    <Button Text=           "Próximo"
-                            Image=          "chevron_right_24.png"
-                            Style=          "{StaticResource FormRightButton}"
-                            Clicked=        "OnProximoClicked"/>
+                <StackLayout>
+                    <StackLayout Orientation=   "Horizontal" >
+                        <Button Text=           "Anterior"
+                                Image=          "chevron_left_orange_24.png"
+                                Style=          "{StaticResource FormLeftButton}"
+                                Clicked=        "OnAnteriorClicked"/>
+
+                        <Button Text=           "Próximo"
+                                Image=          "chevron_right_24.png"
+                                Style=          "{StaticResource FormRightButton}"
+                                Clicked=        "OnProximoClicked"/>
+
+                    </StackLayout>
+                    <Button Text=           "Cancelar"
+                            Image=          "close_red_24.png"
+                            Style=          "{StaticResource FormCancelButton}"
+                            Clicked=        "OnCancelClicked"/>
                 </StackLayout>
             </StackLayout>
         </ScrollView>

--- a/GeCO/GeCO/Views/AutoArguidoPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoArguidoPage.xaml.cs
@@ -9,13 +9,16 @@ namespace GeCO.Views {
     
     public partial class AutoArguidoPage : ContentPage {
         private int currentAutoId, currentArguidoId;
+        private bool isNewAuto;
         private Pessoa _pessoa;
 
 
-        public AutoArguidoPage(int id) {
+        public AutoArguidoPage(int id, bool state) {
             InitializeComponent();
 
             BindingContext = new AutoArguidoVM();
+            
+            isNewAuto = state;
             currentAutoId = id;
         }
 
@@ -134,12 +137,27 @@ namespace GeCO.Views {
 
             await loadAndSave();
 
-            var page = new AutoApreensaoPage(currentAutoId);
+            var page = new AutoApreensaoPage(currentAutoId, isNewAuto);
             await Navigation.PushAsync(page);
 
             IsEnabled = true;
         }
 
+
+        /// <summary>
+        /// Fecha todas as janelas do form e volta à página inicial. Se o utilizdor desejar pode também apagar a informação do auto.
+        /// </summary>
+        async void OnCancelClicked(object sender, System.EventArgs e) {
+            IsEnabled = false;
+
+            if (isNewAuto) {
+                bool isDeletable = await DisplayAlert("Atenção", "Está prestes a sair do formulário.\nPretende também apagar a informação já inserida?", "Sim", "Não");
+                if (isDeletable)
+                    await (BindingContext as AutoArguidoVM).ApagarAuto(currentAutoId);
+            }
+            await Navigation.PopToRootAsync();
+            IsEnabled = true;
+        }
 
 
         /// <summary>
@@ -160,7 +178,6 @@ namespace GeCO.Views {
                 Email =             email.Text
             };
         }
-
 
 
         /// <summary>

--- a/GeCO/GeCO/Views/AutoLegislacaoPage.xaml
+++ b/GeCO/GeCO/Views/AutoLegislacaoPage.xaml
@@ -17,152 +17,175 @@
 
     <ContentPage.Content>
 <!--        <ScrollView>-->
-            <StackLayout>
-                <StackLayout Padding="10,15,10,10" >
-                  <local:StepRenderer StepColor="{StaticResource SecondaryColor}" Steps="7" StepSelected="2" x:Name="stepBar"/>
-                </StackLayout>
+        <StackLayout>
+            <StackLayout Padding="10,15,10,10" >
+                <local:StepRenderer StepColor="{StaticResource SecondaryColor}" Steps="7" StepSelected="2" x:Name="stepBar"/>
+            </StackLayout>
 
 
-                <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-                <!-- ~~~~~~~~ Legislação / Lei ~~~~~~~~ -->
-                <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-                <Frame Style="{StaticResource FormFrame}" >
-                    <StackLayout>
-                        <StackLayout Style=            "{StaticResource FormHeader}">
-                            <Label Text=               "Lei"
+            <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+            <!-- ~~~~~~~~ Legislação / Lei ~~~~~~~~ -->
+            <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+            <Frame Style="{StaticResource FormFrame}" >
+                <StackLayout>
+                    <StackLayout Style=            "{StaticResource FormHeader}">
+                        <Label Text=               "Lei"
                                    Style=              "{StaticResource FormSectionLabel}" />
-                            <Image x:Name=             "leiArrow"
+                        <Image x:Name=             "leiArrow"
                                    Source=             "chevron_down_blue_24.png"
                                    HorizontalOptions = "End" />
-                            <StackLayout.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnLeiTapped" />
-                            </StackLayout.GestureRecognizers>
-                        </StackLayout>
+                        <StackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLeiTapped" />
+                        </StackLayout.GestureRecognizers>
+                    </StackLayout>
 
-                        <StackLayout x:Name="leiStack"
+                    <StackLayout x:Name="leiStack"
                                      IsVisible=         "true">
-                            <Grid  Padding=             "15,5,15,10"
+                        <Grid  Padding=             "15,5,15,10"
                                    RowSpacing=          "0"
                                    ColumnSpacing=       "5">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" /> <!-- 00 -->
-                                    <RowDefinition Height="Auto" /> <!-- 01 -->
-                                    <RowDefinition Height="Auto" /> <!-- 02 -->
-                                    <RowDefinition Height="Auto" /> <!-- 03 -->
-                                    <RowDefinition Height="Auto" /> <!-- 04 -->
-                                    <RowDefinition Height="Auto" /> <!-- 05 -->
-                                    <RowDefinition Height="Auto" /> <!-- 06 -->
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />  <!-- 01 -->
-                                    <ColumnDefinition Width="*" />  <!-- 02 -->
-                                    <ColumnDefinition Width="*" />  <!-- 03 -->
-                                    <ColumnDefinition Width="*" />  <!-- 04 -->
-                                </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <!-- 00 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 01 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 02 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 03 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 04 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 05 -->
+                                <RowDefinition Height="Auto" />
+                                <!-- 06 -->
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <!-- 01 -->
+                                <ColumnDefinition Width="*" />
+                                <!-- 02 -->
+                                <ColumnDefinition Width="*" />
+                                <!-- 03 -->
+                                <ColumnDefinition Width="*" />
+                                <!-- 04 -->
+                            </Grid.ColumnDefinitions>
 
-                                <!-- Título -->
-                                <Label Text=            "Título"
+                            <!-- Título -->
+                            <Label Text=            "Título"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        Grid.Row=        "0"
                                        Grid.Column=     "0"
                                        Grid.ColumnSpan= "3" />
-                                <Picker x:Name="titulo"
+                            <Picker x:Name="titulo"
                                         ItemsSource=    "{Binding Titulo}"
                                         SelectedItem=   "{Binding Lei.Titulo, Mode=TwoWay}"
                                         SelectedIndexChanged="OnIndexChanged"
                                         Style=          "{StaticResource FormPicker}"
                                         Grid.Row=       "1"
                                         Grid.Column=    "0"
-                                        Grid.ColumnSpan="3" />                               
-                                <!-- Pontos Subtraídos -->
-                                <Label Text=            "Pontos"
+                                        Grid.ColumnSpan="3" />
+                            <!-- Pontos Subtraídos -->
+                            <Label Text=            "Pontos"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        Grid.Row=        "0"
                                        Grid.Column=     "3" />
-<!-- Binding -->                <Label x:Name="pontos"
+                            <!-- Binding -->
+                            <Label x:Name="pontos"
                                        Text=            "{Binding Lei.Pontos, Mode=TwoWay}"
                                        Style=           "{StaticResource FormLabel}"
                                        Grid.Row=        "1"
                                        Grid.Column=     "3" />
 
-                                <!-- Descrição Lei -->
-                                <Label Text=            "Descrição da Lei"
+                            <!-- Descrição Lei -->
+                            <Label Text=            "Descrição da Lei"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        Grid.Row=        "2"
                                        Grid.Column=     "0"
                                        Grid.ColumnSpan= "4"/>
-<!-- Binding -->                <Label x:Name="descricao"
+                            <!-- Binding -->
+                            <Label x:Name="descricao"
                                        Text=            "{Binding Lei.Descricao, Mode=TwoWay}"
                                        Style=           "{StaticResource FormLabel}"
                                        Grid.Row=        "3"
                                        Grid.Column=     "0"
                                        Grid.ColumnSpan= "4"/>
 
-                            
-                                
-                                <!-- Coimas -->
-                                <Label Text=            "Coimas"
+
+
+                            <!-- Coimas -->
+                            <Label Text=            "Coimas"
                                        Style=           "{StaticResource FormSubtitleLabel}"
                                        Grid.Row=        "4"
                                        Grid.Column=     "0"
                                        Grid.ColumnSpan= "4"/>
-                                
-                                <!-- Coima Mínima -->
-                                <Label Text=            "Mínimo"
+
+                            <!-- Coima Mínima -->
+                            <Label Text=            "Mínimo"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        VerticalOptions= "CenterAndExpand"
                                        Grid.Row=        "5"
                                        Grid.Column=     "0" />
-<!-- Binding -->                <Label x:Name="min"
+                            <!-- Binding -->
+                            <Label x:Name="min"
                                        Text=            "{Binding Lei.Min, Mode=TwoWay}"
                                        Style=           "{StaticResource FormLabel}"
                                        Grid.Row=        "6"
                                        Grid.Column=     "0" />
-                                
-                                <!-- Coima Máxima -->    
-                                <Label Text=            "Máximo"
+
+                            <!-- Coima Máxima -->
+                            <Label Text=            "Máximo"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        VerticalOptions= "CenterAndExpand"
                                        Grid.Row=        "5"
                                        Grid.Column=     "1" />
-<!-- Binding -->                <Label x:Name="max"
+                            <!-- Binding -->
+                            <Label x:Name="max"
                                        Text=            "{Binding Lei.Max, Mode=TwoWay}"
                                        Style=           "{StaticResource FormLabel}"
                                        Grid.Row=        "6"
                                        Grid.Column=     "1" />
-                                
-                                <!-- Prazo -->
-                                <Label Text=            "Prazo"
+
+                            <!-- Prazo -->
+                            <Label Text=            "Prazo"
                                        Style=           "{StaticResource FormTitleLabel}"
                                        VerticalOptions= "CenterAndExpand"
                                        Grid.Row=        "5"
                                        Grid.Column=     "2" />
-<!-- Binding -->                <Label x:Name="prazo"
+                            <!-- Binding -->
+                            <Label x:Name="prazo"
                                        Text=            "{Binding Lei.Prazo, Mode=TwoWay}"
                                        Style=           "{StaticResource FormLabel}"
                                        Grid.Row=        "6"
                                        Grid.Column=     "2" />
-                            </Grid>
-                        </StackLayout>
+                        </Grid>
                     </StackLayout>
-                </Frame>            
+                </StackLayout>
+            </Frame>
 
-                                
 
-                <!-- ~~~~~~ Botões ~~~~~~ -->
+
+            <!-- ~~~~~~ Botões ~~~~~~ -->
+            <StackLayout>
                 <StackLayout Orientation=   "Horizontal" >
                     <Button Text=           "Anterior"
                             Image=          "chevron_left_orange_24.png"
                             Style=          "{StaticResource FormLeftButton}"
                             Clicked=        "OnAnteriorClicked"/>
-                    
+
                     <Button Text=           "Próximo"
                             Image=          "chevron_right_24.png"
                             Style=          "{StaticResource FormRightButton}"
                             Clicked=        "OnProximoClicked"/>
+
                 </StackLayout>
+                <Button Text=           "Cancelar"
+                        Image=          "close_red_24.png"
+                        Style=          "{StaticResource FormCancelButton}"
+                        Clicked=        "OnCancelClicked"/>
             </StackLayout>
-<!--        </ScrollView>-->
+        </StackLayout>
+        <!--        </ScrollView>-->
 
     </ContentPage.Content>
 </ContentPage>

--- a/GeCO/GeCO/Views/AutoLegislacaoPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoLegislacaoPage.xaml.cs
@@ -103,13 +103,26 @@ namespace GeCO.Views {
 
             await loadAndSave();
 
-            var page = new AutoArguidoPage(currentAutoId);
+            var page = new AutoArguidoPage(currentAutoId, isNewAuto);
             await Navigation.PushAsync(page);
 
             IsEnabled = true;
         }
 
+        /// <summary>
+        /// Fecha todas as janelas do form e volta à página inicial. Se o utilizdor desejar pode também apagar a informação do auto.
+        /// </summary>
+        async void OnCancelClicked(object sender, System.EventArgs e) {
+            IsEnabled = false;
 
+            if (isNewAuto) {
+                bool isDeletable = await DisplayAlert("Atenção", "Está prestes a sair do formulário.\n Pretende também apagar a informação já inserida?", "Sim", "Não");
+                if (isDeletable)
+                    await (BindingContext as AutoLegislacaoVM).ApagarAuto(currentAutoId);
+            }
+            await Navigation.PopToRootAsync();
+            IsEnabled = true;
+        }
 
 
         /// <summary>
@@ -137,6 +150,7 @@ namespace GeCO.Views {
             currentLeiId = leg.LeiId;
         }
 
+
         /// <summary>
         /// Limpa o texto das entries e seleciona os valores default dos dropdowns.
         /// </summary>
@@ -152,7 +166,7 @@ namespace GeCO.Views {
         }
 
 
-
+        #region Properties
         public Lei Lei {
             get { return _lei; }
             set {
@@ -160,7 +174,10 @@ namespace GeCO.Views {
                 OnPropertyChanged();
             }
         }
+        #endregion
 
+
+        #region Tap Separador
         void OnLeiTapped(object sender, System.EventArgs e) {
             leiStack.IsVisible = !leiStack.IsVisible;
 
@@ -169,5 +186,6 @@ namespace GeCO.Views {
             else
                 leiArrow.RotateTo(0, 225);
         }
+        #endregion
     }
 }

--- a/GeCO/GeCO/Views/AutoPagamentoPage.xaml
+++ b/GeCO/GeCO/Views/AutoPagamentoPage.xaml
@@ -269,19 +269,26 @@
                             </Grid>
                         </StackLayout>
                     </StackLayout>
-                </Frame>            
+                </Frame>
 
                 <!-- ~~~~~~ Botões ~~~~~~ -->
-                <StackLayout Orientation=   "Horizontal" >
-                    <Button Text=           "Anterior"
-                            Image=          "chevron_left_orange_24.png"
-                            Style=          "{StaticResource FormLeftButton}"
-                            Clicked=        "OnAnteriorClicked"/>
-                    
-                    <Button Text=           "Próximo"
-                            Image=          "chevron_right_24.png"
-                            Style=          "{StaticResource FormRightButton}"
-                            Clicked=        "OnProximoClicked"/>
+                <StackLayout>
+                    <StackLayout Orientation=   "Horizontal" >
+                        <Button Text=           "Anterior"
+                                Image=          "chevron_left_orange_24.png"
+                                Style=          "{StaticResource FormLeftButton}"
+                                Clicked=        "OnAnteriorClicked"/>
+
+                        <Button Text=           "Próximo"
+                                Image=          "chevron_right_24.png"
+                                Style=          "{StaticResource FormRightButton}"
+                                Clicked=        "OnProximoClicked"/>
+
+                    </StackLayout>
+                    <Button Text=           "Cancelar"
+                            Image=          "close_red_24.png"
+                            Style=          "{StaticResource FormCancelButton}"
+                            Clicked=        "OnCancelClicked"/>
                 </StackLayout>
             </StackLayout>
         </ScrollView>

--- a/GeCO/GeCO/Views/AutoPagamentoPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoPagamentoPage.xaml.cs
@@ -10,12 +10,14 @@ namespace GeCO.Views {
     public partial class AutoPagamentoPage : ContentPage {
         
         private int currentAutoId, currentPagamentoId;
+        bool isNewAuto;
 
-        public AutoPagamentoPage(int id) {
+        public AutoPagamentoPage(int id, bool state) {
             InitializeComponent();
 
-            currentAutoId = id;
             BindingContext = new AutoPagamentoVM();
+            currentAutoId = id;
+            isNewAuto = state;
         }
 
 
@@ -74,13 +76,28 @@ namespace GeCO.Views {
         async void OnProximoClicked(object sender, System.EventArgs e) {
             IsEnabled = false;
 
-            var page = new AutoTestemunhaPage(currentAutoId);
+            var page = new AutoTestemunhaPage(currentAutoId, isNewAuto);
             await Navigation.PushAsync(page);
 
             IsEnabled = true;
         }
 
-        
+        /// <summary>
+        /// Fecha todas as janelas do form e volta à página inicial. Se o utilizdor desejar pode também apagar a informação do auto.
+        /// </summary>
+        async void OnCancelClicked(object sender, System.EventArgs e) {
+            IsEnabled = false;
+
+            if (isNewAuto) {
+                bool isDeletable = await DisplayAlert("Atenção", "Está prestes a sair do formulário.\nPretende também apagar a informação já inserida?", "Sim", "Não");
+                if (isDeletable)
+                    await (BindingContext as AutoPagamentoVM).ApagarAuto(currentAutoId);
+            }
+            await Navigation.PopToRootAsync();
+            IsEnabled = true;
+        }
+
+
         #region Taps Separadores
         void OnPagamentoTapped(object sender, System.EventArgs e) {
             pagamentoStack.IsVisible = !pagamentoStack.IsVisible;

--- a/GeCO/GeCO/Views/AutoPrincipalPage.xaml
+++ b/GeCO/GeCO/Views/AutoPrincipalPage.xaml
@@ -656,7 +656,7 @@
                 <StackLayout Orientation=   "Horizontal" >
                     <Button Text=           "Cancelar"
                             Image=          "close_red_24.png"
-                            Style=          "{StaticResource FormCancelButton}"
+                            Style=          "{StaticResource CancelBtnPrincPage}"
                             Clicked=        "OnCancelarClicked" />
                                             
                     <Button Text=           "Próximo"

--- a/GeCO/GeCO/Views/AutoResumoPage.xaml
+++ b/GeCO/GeCO/Views/AutoResumoPage.xaml
@@ -38,7 +38,7 @@
                         Style=          "{StaticResource FormFinalBackButton}"
                         Clicked=        "OnAnteriorClicked"/>
                                         
-                <Button Text=           "Apagar Auto"
+                <Button Text=           "Cancelar"
                         Image=          "close_red_24.png"
                         Style=          "{StaticResource FormFinalCancelButton}"
                         VerticalOptions="EndAndExpand"

--- a/GeCO/GeCO/Views/AutoResumoPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoResumoPage.xaml.cs
@@ -8,8 +8,9 @@ namespace GeCO.Views {
     
     public partial class AutoResumoPage : ContentPage {
         private int currentAutoId;
+        private bool isNewAuto;
 
-        public AutoResumoPage(int id) {
+        public AutoResumoPage(int id, bool state) {
             InitializeComponent();
 
             currentAutoId = id;

--- a/GeCO/GeCO/Views/AutoTestemunhaPage.xaml
+++ b/GeCO/GeCO/Views/AutoTestemunhaPage.xaml
@@ -249,21 +249,28 @@
                             </Grid>
                         </StackLayout>
                     </StackLayout>
-                </Frame>            
+                </Frame>
 
 
-                
+
                 <!-- ~~~~~~ Botões ~~~~~~ -->
-                <StackLayout Orientation=   "Horizontal" >
-                    <Button Text=           "Anterior"
-                            Image=          "chevron_left_orange_24.png"
-                            Style=          "{StaticResource FormLeftButton}"
-                            Clicked=        "OnAnteriorClicked"/>
-                    
-                    <Button Text=           "Próximo"
-                            Image=          "chevron_right_24.png"
-                            Style=          "{StaticResource FormRightButton}"
-                            Clicked=        "OnProximoClicked"/>
+                <StackLayout>
+                    <StackLayout Orientation=   "Horizontal" >
+                        <Button Text=           "Anterior"
+                                Image=          "chevron_left_orange_24.png"
+                                Style=          "{StaticResource FormLeftButton}"
+                                Clicked=        "OnAnteriorClicked"/>
+
+                        <Button Text=           "Próximo"
+                                Image=          "chevron_right_24.png"
+                                Style=          "{StaticResource FormRightButton}"
+                                Clicked=        "OnProximoClicked"/>
+
+                    </StackLayout>
+                    <Button Text=           "Cancelar"
+                            Image=          "close_red_24.png"
+                            Style=          "{StaticResource FormCancelButton}"
+                            Clicked=        "OnCancelClicked"/>
                 </StackLayout>
             </StackLayout>
         </ScrollView>

--- a/GeCO/GeCO/Views/AutoTestemunhaPage.xaml.cs
+++ b/GeCO/GeCO/Views/AutoTestemunhaPage.xaml.cs
@@ -9,14 +9,16 @@ namespace GeCO.Views {
     public partial class AutoTestemunhaPage : ContentPage {
         
         private int currentAutoId, currentTestemunhaId;
+        private bool isNewAuto;
         private Pessoa _pessoa;
 
          
-        public AutoTestemunhaPage(int id) {
+        public AutoTestemunhaPage(int id, bool state) {
             InitializeComponent();
 
-            currentAutoId = id;
             BindingContext = new AutoTestemunhaVM();
+            currentAutoId = id;
+            isNewAuto = state;
         }
 
 
@@ -132,12 +134,27 @@ namespace GeCO.Views {
 
             await loadAndSave();
 
-            var page = new AutoResumoPage(currentAutoId);
+            var page = new AutoResumoPage(currentAutoId, isNewAuto);
             await Navigation.PushAsync(page);
 
             IsEnabled = true;
         }
 
+
+        /// <summary>
+        /// Fecha todas as janelas do form e volta à página inicial. Se o utilizdor desejar pode também apagar a informação do auto.
+        /// </summary>
+        async void OnCancelClicked(object sender, System.EventArgs e)  {
+            IsEnabled = false;
+
+            if (isNewAuto) {
+                bool isDeletable = await DisplayAlert("Atenção", "Está prestes a sair do formulário.\nPretende também apagar a informação já inserida?", "Sim", "Não");
+                if (isDeletable)
+                    await (BindingContext as AutoTestemunhaVM).ApagarAuto(currentAutoId);
+            }
+            await Navigation.PopToRootAsync();
+            IsEnabled = true;
+        }
 
 
         /// <summary>


### PR DESCRIPTION
- Anteriormente era impossível simplesmente fechar o formulário e voltar à homepage. Foram adicionados botões para o efeito (afetando os ficheiros da UI, code behind e VMs de todas essas páginas);
- XAML relativo aos botões era repetitivo e sofreu uma refatorado.